### PR TITLE
Feat/change h2 to mysql db by docker

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,3 +7,8 @@ build/
 
 
 .idea/
+
+
+# db data
+sns-mysql/
+sns-mysql-conf/

--- a/build.gradle
+++ b/build.gradle
@@ -24,6 +24,7 @@ repositories {
 dependencies {
 	implementation 'org.springframework.boot:spring-boot-starter-data-jpa'
 	implementation 'org.springframework.boot:spring-boot-starter-web'
+	runtimeOnly 'com.h2database:h2'
 	compileOnly 'org.projectlombok:lombok'
 	annotationProcessor 'org.projectlombok:lombok'
 	testImplementation 'org.springframework.boot:spring-boot-starter-test'

--- a/build.gradle
+++ b/build.gradle
@@ -24,7 +24,7 @@ repositories {
 dependencies {
 	implementation 'org.springframework.boot:spring-boot-starter-data-jpa'
 	implementation 'org.springframework.boot:spring-boot-starter-web'
-	runtimeOnly 'com.h2database:h2'
+	runtimeOnly 'com.mysql:mysql-connector-j'
 	compileOnly 'org.projectlombok:lombok'
 	annotationProcessor 'org.projectlombok:lombok'
 	testImplementation 'org.springframework.boot:spring-boot-starter-test'

--- a/docker/docker-compose.yml
+++ b/docker/docker-compose.yml
@@ -1,0 +1,18 @@
+version: "3"
+services:
+  sns-mysql:
+    platform: linux/x86_64
+    image: amd64/mysql:8.0.34
+    container_name: sns-db
+    environment:
+      MYSQL_ROOT_PASSWORD: chlqus310@
+      MYSQL_DATABASE: sns
+    ports:
+      - "3306:3306"
+    volumes:
+      - ../sns-mysql:/var/lib/mysql
+      - ../sns-mysql-conf:/etc/mysql/conf.d
+    command:
+      - --character-set-server=utf8mb4
+      - --collation-server=utf8mb4_unicode_ci
+    restart: always

--- a/src/main/java/com/youngjun/sns/user/controller/UserController.java
+++ b/src/main/java/com/youngjun/sns/user/controller/UserController.java
@@ -1,0 +1,23 @@
+package com.youngjun.sns.user.controller;
+
+import com.youngjun.sns.user.dto.response.GetUserResponse;
+import com.youngjun.sns.user.entity.User;
+import com.youngjun.sns.user.service.UserService;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.*;
+
+@RestController
+@RequestMapping("/users")
+@RequiredArgsConstructor
+@Slf4j
+public class UserController {
+    private final UserService userService;
+
+    @GetMapping("/{id}")
+    public ResponseEntity<GetUserResponse> getUser(@PathVariable Long id){
+        User user = userService.getUserById(id);
+        return ResponseEntity.ok(new GetUserResponse(user));
+    }
+}

--- a/src/main/java/com/youngjun/sns/user/dto/response/GetUserResponse.java
+++ b/src/main/java/com/youngjun/sns/user/dto/response/GetUserResponse.java
@@ -1,0 +1,19 @@
+package com.youngjun.sns.user.dto.response;
+
+import com.youngjun.sns.user.entity.User;
+import lombok.Getter;
+
+@Getter
+public class GetUserResponse {
+    private Long id;
+    private String email;
+    private String phoneNumber;
+    private Long age;
+
+    public GetUserResponse(User user){
+        this.id = user.getId();
+        this.age = user.getAge();
+        this.email = user.getEmail();
+        this.phoneNumber = user.getPhoneNumber();
+    }
+}

--- a/src/main/java/com/youngjun/sns/user/entity/User.java
+++ b/src/main/java/com/youngjun/sns/user/entity/User.java
@@ -1,0 +1,21 @@
+package com.youngjun.sns.user.entity;
+
+import jakarta.persistence.*;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Data;
+
+@Entity
+@Data
+@Builder
+@AllArgsConstructor
+public class User {
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    private String email;
+    private String password;
+    private String phoneNumber;
+    private Long age;
+}

--- a/src/main/java/com/youngjun/sns/user/repository/UserRepository.java
+++ b/src/main/java/com/youngjun/sns/user/repository/UserRepository.java
@@ -1,0 +1,10 @@
+package com.youngjun.sns.user.repository;
+
+
+import com.youngjun.sns.user.entity.User;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.stereotype.Repository;
+
+@Repository
+public interface UserRepository extends JpaRepository<User, Long> {
+}

--- a/src/main/java/com/youngjun/sns/user/service/UserService.java
+++ b/src/main/java/com/youngjun/sns/user/service/UserService.java
@@ -1,0 +1,20 @@
+package com.youngjun.sns.user.service;
+
+import com.youngjun.sns.user.entity.User;
+import com.youngjun.sns.user.repository.UserRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+
+@Service
+@RequiredArgsConstructor
+public class UserService {
+    private final UserRepository userRepository;
+
+    public User getUserById(Long id){
+        return userRepository.findById(id).orElseThrow(
+                () -> new RuntimeException("유저 정보 없음")
+        );
+    }
+}
+
+

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -1,0 +1,13 @@
+spring:
+  datasource:
+    url: jdbc:h2:mem:until;NON_KEYWORDS=USER,ORDER
+    username: tester
+    password: qwer!@#$
+    driverClassName: org.h2.Driver
+  jpa:
+    database-platform: org.hibernate.dialect.H2Dialect
+    hibernate:
+      ddl-auto: create-drop
+  h2:
+    console:
+      enabled: true

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -1,13 +1,13 @@
 spring:
   datasource:
-    url: jdbc:h2:mem:until;NON_KEYWORDS=USER,ORDER
-    username: tester
-    password: qwer!@#$
-    driverClassName: org.h2.Driver
+    driver-class-name: com.mysql.cj.jdbc.Driver
+    url: jdbc:mysql://localhost:3306/sns
+    username: root
+    password: chlqus310@
   jpa:
-    database-platform: org.hibernate.dialect.H2Dialect
+    database: mysql
     hibernate:
       ddl-auto: create-drop
-  h2:
-    console:
-      enabled: true
+    properties:
+      hibernate:
+        show_sql: true


### PR DESCRIPTION
임시로 사용중이던 h2 in-memory DB를 msyql로 변경.
- 변경하기 위해 docker-compose.yml을 작성하여 mysql 8.0.34 버전으로 구성.
- mysql과 연동하기위해 gradle 추가.
- msyql과 연동하기 위해 application.yml 파일에 db 정보 추가