### PR TITLE
feat : 사용 DB를 mysql로 변경

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,3 +7,8 @@ build/
 
 
 .idea/
+
+
+# db data
+sns-mysql/
+sns-mysql-conf/

--- a/build.gradle
+++ b/build.gradle
@@ -24,7 +24,7 @@ repositories {
 dependencies {
 	implementation 'org.springframework.boot:spring-boot-starter-data-jpa'
 	implementation 'org.springframework.boot:spring-boot-starter-web'
-	runtimeOnly 'com.h2database:h2'
+	runtimeOnly 'com.mysql:mysql-connector-j'
 	compileOnly 'org.projectlombok:lombok'
 	annotationProcessor 'org.projectlombok:lombok'
 	testImplementation 'org.springframework.boot:spring-boot-starter-test'

--- a/docker/docker-compose.yml
+++ b/docker/docker-compose.yml
@@ -1,0 +1,18 @@
+version: "3"
+services:
+  sns-mysql:
+    platform: linux/x86_64
+    image: amd64/mysql:8.0.34
+    container_name: sns-db
+    environment:
+      MYSQL_ROOT_PASSWORD: chlqus310@
+      MYSQL_DATABASE: sns
+    ports:
+      - "3306:3306"
+    volumes:
+      - ../sns-mysql:/var/lib/mysql
+      - ../sns-mysql-conf:/etc/mysql/conf.d
+    command:
+      - --character-set-server=utf8mb4
+      - --collation-server=utf8mb4_unicode_ci
+    restart: always

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -1,13 +1,13 @@
 spring:
   datasource:
-    url: jdbc:h2:mem:until;NON_KEYWORDS=USER,ORDER
-    username: tester
-    password: qwer!@#$
-    driverClassName: org.h2.Driver
+    driver-class-name: com.mysql.cj.jdbc.Driver
+    url: jdbc:mysql://localhost:3306/sns
+    username: root
+    password: chlqus310@
   jpa:
-    database-platform: org.hibernate.dialect.H2Dialect
+    database: mysql
     hibernate:
       ddl-auto: create-drop
-  h2:
-    console:
-      enabled: true
+    properties:
+      hibernate:
+        show_sql: true


### PR DESCRIPTION
임시로 사용중이던 h2 in-memory DB를 msyql로 변경.

- 변경하기 위해 docker-compose.yml을 작성하여 mysql 8.0.34 버전으로 구성.
- mysql과 연동하기위해 gradle 추가.
- msyql과 연동하기 위해 application.yml 파일에 db 정보 추가
- .gitignore에 db 관련 데이터 폴더 추가하여 github에 db관련 정보가 안올라가게 변경.